### PR TITLE
Little update for bugsnag error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ const defaultOptions = {
   cors: {},
   compression: true,
   error: {
-    defaultErrorCode: 500
+    defaultErrorCode: 500,
+    channels: []
   }
 }
 
@@ -94,9 +95,12 @@ export default class ExpressApplication {
    *
    * @param {Object} err - Error throwed
    */
-  notify(err) {
-    if (prop('key', this.options.bugsnag)) {
-      bugsnag.notify(err)
-    }
+  async notify(err) {
+    return this.error
+      .channels
+      .reduce((acc, channel) => {
+        acc.push(channel.notify(err))
+        return acc;
+      }, [])
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,4 @@
-import bugsnag from 'bugsnag'
 import express from 'express'
-import { prop } from 'ramda'
 import ExpressServiceDiscovery from './src/expressServiceDiscovery'
 import ExpressMiddlewares from './src/expressMiddlewares'
 
@@ -96,11 +94,11 @@ export default class ExpressApplication {
    * @param {Object} err - Error throwed
    */
   async notify(err) {
-    return this.error
-      .channels
+    return this.error.channels
       .reduce((acc, channel) => {
         acc.push(channel.notify(err))
         return acc;
       }, [])
   }
 }
+

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
     "dist"
   ],
   "dependencies": {
+    "@bugsnag/js": "^6.0.0",
+    "@bugsnag/plugin-express": "^6.0.0",
     "body-parser": "^1.18.3",
-    "bugsnag": "^2.4.3",
     "compression": "^1.7.3",
     "cors": "^2.8.5",
     "express": "^4.16.4",

--- a/src/expressMiddlewares.js
+++ b/src/expressMiddlewares.js
@@ -1,3 +1,6 @@
+import bugsnag from '@bugsnag/js'
+import bugsnagExpress from '@bugsnag/plugin-express'
+
 import bodyParser from 'body-parser'
 import compression from 'compression'
 import cors from 'cors'
@@ -42,13 +45,14 @@ export default class ExpressMiddlewares {
     this.register(bodyParser.json, jsonOpts)
     this.register(bodyParser.urlencoded, { extended: false, limit: '1mb' })
 
-    if (prop('key', this.options.bugsnag)) {
-      const { key, ...bugsnagOptions } = this.options.bugsnag
+    if (prop('apiKey', this.options.bugsnag)) {
+      const bugsnagClient = bugsnag(this.options.bugsnag)
+      bugsnagClient.use(bugsnagExpress)
+      const bugsnagMiddlewares = bugsnagClient.getPlugin('express')
+      this.register(bugsnagMiddlewares.requestHandler)
+      this.register(bugsnagMiddlewares.errorHandler)
 
-      bugsnag.register(key, bugsnagOptions)
-
-      this.register(bugsnag.requestHandler)
-      this.register(bugsnag.errorHandler)
+      this.app.error.channels.push(bugsnagClient)
     }
   }
 

--- a/src/expressMiddlewares.js
+++ b/src/expressMiddlewares.js
@@ -45,9 +45,12 @@ export default class ExpressMiddlewares {
     this.register(bodyParser.json, jsonOpts)
     this.register(bodyParser.urlencoded, { extended: false, limit: '1mb' })
 
-    if (prop('apiKey', this.options.bugsnag)) {
-      const bugsnagClient = bugsnag(this.options.bugsnag)
+    if (prop('key', this.options.bugsnag)) {
+      const { key, ...bugsnagOptions } = this.options.bugsnag
+
+      const bugsnagClient = bugsnag({ apiKey: key, ...bugsnagOptions })
       bugsnagClient.use(bugsnagExpress)
+
       const bugsnagMiddlewares = bugsnagClient.getPlugin('express')
       this.register(bugsnagMiddlewares.requestHandler)
       this.register(bugsnagMiddlewares.errorHandler)


### PR DESCRIPTION
Hey :)

For errors:
- Added error channels that expect a `.notify()` method, you may create your own.
- Updated for new Bugsnag api