### PR TITLE
Support for bugsnag metaData

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ export default class ExpressApplication {
    */
   errorDispatcher (err, request, response, next) {
     const metaData = err.metaData || {}
+    const errorCode = err.errorCode || this.options.error.defaultErrorCode
 
     this.notify(err, metaData)
     if (request.bugsnag) request.bugsnag.notify(err, { metaData })
@@ -85,12 +86,10 @@ export default class ExpressApplication {
 
     if (err instanceof Error) {
       const { name, message } = err
-      const errorCode = err.errorCode || this.options.error.defaultErrorCode
-
       return response.status(errorCode).json({ errorCode, name, message })
     }
 
-    response.status(this.options.error.defaultErrorCode).json({ message: 'unexpected error.' })
+    response.status(errorCode).json({ message: 'unexpected error.' })
   }
 
   /**

--- a/src/expressMiddlewares.js
+++ b/src/expressMiddlewares.js
@@ -54,8 +54,6 @@ export default class ExpressMiddlewares {
       const bugsnagMiddlewares = bugsnagClient.getPlugin('express')
       this.register(() => bugsnagMiddlewares.requestHandler)
       this.register(() => bugsnagMiddlewares.errorHandler)
-
-      this.app.channels.push(bugsnagClient)
     }
   }
 

--- a/src/expressMiddlewares.js
+++ b/src/expressMiddlewares.js
@@ -52,10 +52,10 @@ export default class ExpressMiddlewares {
       bugsnagClient.use(bugsnagExpress)
 
       const bugsnagMiddlewares = bugsnagClient.getPlugin('express')
-      this.register(bugsnagMiddlewares.requestHandler)
-      this.register(bugsnagMiddlewares.errorHandler)
+      this.register(() => bugsnagMiddlewares.requestHandler)
+      this.register(() => bugsnagMiddlewares.errorHandler)
 
-      this.app.error.channels.push(bugsnagClient)
+      this.app.channels.push(bugsnagClient)
     }
   }
 


### PR DESCRIPTION
Hey! :)

Added:
- Support for `metaData` if you add that attribute for your error class at application level. This way make it easier to help publish context related error.

```js
// src/services/products-service.js
export default class SystemsService {
  async show (req, res, next) {
    const { query, params, baseUrl } = req
    if (!query.page) {
      const e = new Error('There is no page reference')
        e.metaData = { baseUrl, productId: params.productId }
        next(e)
    }
  }
}

// or even...

class PageNotSetError extends Error {
  constructor(metaData = {}) {
     super('request-without-page-reference')
     this.errorCode = 400
     this.metaData = metaData
  }
}
export default class SystemsService {
  async show (req, res, next) {
    const { query, params, baseUrl } = req
    if (!query.page) {
      next(new PageNotSetError({ baseUrl, productId: params.productId }))
    }
  }
}
```

Fix:
- `bugsnag` middleware was not working with `ExpressMiddlewares.register`
- Removed auto-sign for `bugsnagClient` on `ExpressApplication.channels`, could trigger twice the same bug.
